### PR TITLE
Fix/take master and current into account

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
+}

--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-'use strict';
+'use strict'
 
 const inquirer = require('inquirer')
 const git = require('simple-git/promise')()
@@ -7,7 +7,7 @@ const git = require('simple-git/promise')()
 function validate(summary) {
   const { all, current } = summary
 
-  return (!all || all === 0)
+  return !all || all === 0
     ? Promise.reject('[delete-branches] No branches found')
     : { branches: all, current }
 }
@@ -15,9 +15,9 @@ function validate(summary) {
 function parse(summary) {
   const { branches, current } = summary
 
-  return (branches.length === 1)
+  return branches.length === 1
     ? Promise.reject('[delete-branches] You have only one branch')
-    : branches.filter(b => b !== 'master' && b !== current)
+    : branches.filter((b) => b !== 'master' && b !== current)
 }
 
 function format(branches) {
@@ -25,18 +25,20 @@ function format(branches) {
 }
 
 function ask(choices) {
-  return inquirer.prompt([{
-    type: 'checkbox',
-    name: 'branches',
-    message: '[delete-branches] Select the branches you want to delete:',
-    choices,
-  }])
+  return inquirer.prompt([
+    {
+      type: 'checkbox',
+      name: 'branches',
+      message: '[delete-branches] Select the branches you want to delete:',
+      choices,
+    },
+  ])
 }
 
 function remove(answers) {
   const { branches } = answers
 
-  if(!branches.length) {
+  if (!branches.length) {
     return console.log('[delete-branches] No branches deleted')
   }
 

--- a/cli.js
+++ b/cli.js
@@ -14,10 +14,17 @@ function validate(summary) {
 
 function parse(summary) {
   const { branches, current } = summary
+  const protectedBranches = ['master', 'main', current]
 
-  return branches.length === 1
-    ? Promise.reject('[delete-branches] You have only one branch')
-    : branches.filter((b) => b !== 'master' && b !== current)
+  const filteredBranches = branches.filter(
+    (branch) => !protectedBranches.includes(branch)
+  )
+
+  return filteredBranches.length < 1
+    ? Promise.reject(
+        '[delete-branches] You have no branches to delete except main/master and current branch'
+      )
+    : filteredBranches
 }
 
 function format(branches) {


### PR DESCRIPTION


## Add a Prettier conf and format `cli.js` with Prettier

If collaborating on a project it's helpful to have a Prettier conf so that code becomes homogenous. 

(to be honest: my VSCode runs Prettier formatting on all JS files and I'm so lazy that I never format my code manually anymore. Do you think it's a good idea?)

## Take current branch and `master`/`main` into consideration when listing branches to delete

Otherwise, when you're on a feature branch, you will have two branches in the repository (`master` + feature branch), and the condition `branches.length === 1` will not be true. By defining `filteredBranches` we can give a better error message.

### Screenshots

Given `master` and this current feature branch:

#### Before

<img width="1134" alt="image" src="https://github.com/guilhermepontes/delete-branches/assets/1343979/0bd1d387-d91d-4ead-b9eb-26090a319b23">


#### After

<img width="1134" alt="image" src="https://github.com/guilhermepontes/delete-branches/assets/1343979/1d2e0b8b-0301-4359-9442-ea96005be586">
